### PR TITLE
Adds initial structure and configurations for the EclipseLink Framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,26 @@
 			<artifactId>jakarta.ws.rs-api</artifactId>
 			<version>2.1.6</version>
 		</dependency>
+		<dependency>
+		    <groupId>org.postgresql</groupId>
+		    <artifactId>postgresql</artifactId>
+		    <version>42.2.12</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.persistence</groupId>
+			<artifactId>eclipselink</artifactId>
+			<version>2.7.6</version>
+		</dependency>
+		<dependency>
+		    <groupId>javax.annotation</groupId>
+		    <artifactId>javax.annotation-api</artifactId>
+		    <version>1.3.2</version>
+		</dependency>
+		<dependency>
+		    <groupId>javax.ejb</groupId>
+		    <artifactId>javax.ejb-api</artifactId>
+		    <version>3.2.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/META-INF/persistence.xml
+++ b/src/META-INF/persistence.xml
@@ -1,0 +1,11 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.2"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+    
+    <!-- Define persistence unit -->
+    <persistence-unit name="postgre-sql" transaction-type="JTA">
+        <description>The main relational persistence unit of the project</description>
+        
+        <jta-data-source>java:app/jdbc/primary</jta-data-source>
+    </persistence-unit>
+</persistence>

--- a/src/main/java/msh/gert/api/dev/EndpointTest.java
+++ b/src/main/java/msh/gert/api/dev/EndpointTest.java
@@ -5,6 +5,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
 
 @Path("test")
 @Produces(MediaType.APPLICATION_JSON)
@@ -12,6 +16,23 @@ public class EndpointTest {
 	
 	@GET
 	public Response ping() {
-		return Response.ok("I'm alive").build();
+		Connection conn = null;
+		ResponseBuilder response = null;
+	
+		try{
+            Class.forName("org.postgresql.Driver");     
+		} catch(ClassNotFoundException e) {
+			e.printStackTrace();
+		}
+		
+		try {
+			conn = DriverManager.getConnection("jdbc:postgresql://postgres/gert", "postgres", "dev_password_1508");
+			response = Response.ok("Connection Successfull");
+		} catch (Exception e) {
+			e.printStackTrace();
+			response = Response.ok("OK");
+		}
+		
+		return response.build();
 	}
 }

--- a/src/main/java/msh/gert/db/PostgreDataSourceGenerator.java
+++ b/src/main/java/msh/gert/db/PostgreDataSourceGenerator.java
@@ -1,0 +1,24 @@
+package msh.gert.db;
+
+import javax.annotation.sql.DataSourceDefinition;
+import javax.ejb.Singleton;
+import javax.sql.DataSource;
+
+@Singleton
+@DataSourceDefinition(
+    className = "org.postgresql.ds.PGSimpleDataSource",
+    name = "java:app/jdbc/primary",
+    serverName="postgres",
+    portNumber=3306,
+    user = "postgres",
+    password = "dev_password_1508",
+    databaseName = "gert"
+)
+public class PostgreDataSourceGenerator {
+
+	DataSource ds;
+	
+	public DataSource getDatasource() {
+		return ds;
+	}
+}


### PR DESCRIPTION
## Description
Creates the initial configuration files and package structure to be use with eclipselink. I've choosed this framework due to it being the standard JPA implementation. Besides that, it is a feature rich option and has already been elected as part of the Jakarta specification.

### Related Issues
#5 